### PR TITLE
fix(package): added tzdata to uv so windows systems can run the bot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = "==3.13.*"
 dependencies = [
     "discord-py>=2.6.4",
     "pydantic-settings>=2.12.0",
-    "tzdata>=2025.3",
+    "tzdata>=2025.3; sys_platform == 'win32'",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "discord-py" },
     { name = "pydantic-settings" },
-    { name = "tzdata" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 
 [package.dev-dependencies]
@@ -142,7 +142,7 @@ dev = [
 requires-dist = [
     { name = "discord-py", specifier = ">=2.6.4" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
-    { name = "tzdata", specifier = ">=2025.3" },
+    { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2025.3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure the bot can access time zone data on platforms that do not provide it by default, such as Windows, by depending on tzdata.